### PR TITLE
Added P4 Python support to check out read-only file on save

### DIFF
--- a/operators/p4python.py
+++ b/operators/p4python.py
@@ -1,0 +1,19 @@
+import bpy
+
+
+class Install_P4Python(bpy.types.Operator):
+    bl_idname = "machin3.install_p4python"
+    bl_label = "MACHIN3: Install P4Python"
+    bl_description = "Install official P4 Python module"
+    bl_options = {'REGISTER'}
+
+    def execute(self, context):
+        try:
+            from .. utils.pip import Pip
+            #Pip.upgrade_pip()
+            Pip.install('p4python')
+            print('P4Python successfully installed!')
+            self.report({'INFO'}, 'P4Python successfully installed!')
+        except:
+            print('P4Python not loaded correctly. Try restarting Blender')
+        return {'FINISHED'}

--- a/preferences.py
+++ b/preferences.py
@@ -329,6 +329,8 @@ class MACHIN3toolsPreferences(bpy.types.AddonPreferences):
     HUD_fade_group: FloatProperty(name="Group HUD Fade Time (seconds)", default=1, min=0.1)
     HUD_fade_tools_pie: FloatProperty(name="Tools Pie HUD Fade Time (seconds)", default=0.75, min=0.1)
 
+    # P4 Python
+    use_p4_checkout: BoolProperty(name="Use P4 Checkout on read-only files", default=False)
 
     # hidden
 
@@ -861,6 +863,16 @@ class MACHIN3toolsPreferences(bpy.types.AddonPreferences):
             col = split.column()
             col.prop(self, "tools_show_quick_favorites")
             col.prop(self, "tools_show_tool_bar")
+
+         # P4Python 
+        
+        bb = b.box()
+        bb.label(text="P4 Integration")
+        column = bb.column()
+        column.prop(self, "use_p4_checkout")
+        column = bb.column()
+        column.operator("machin3.install_p4python", text="Install P4Python", icon="PREFERENCES")
+   
 
 
         # NO SETTINGS

--- a/registration.py
+++ b/registration.py
@@ -145,6 +145,7 @@ classes = {'CORE': [('ui.UILists', [('AppendMatsUIList', '')]),
            'TOOLS_PIE': [('ui.pies', [('PieTools', 'tools_pie')]),
                          ('ui.operators.tool', [('SetToolByName', 'set_tool_by_name'),
                                                 ('SetBCPreset', 'set_boxcutter_preset')])],
+           'P4PYTHON': [('operators.p4python', [('Install_P4Python', 'install_p4python')])],
            }
 
 

--- a/ui/operators/save.py
+++ b/ui/operators/save.py
@@ -44,16 +44,44 @@ class Save(bpy.types.Operator):
             return f"Save {currentblend}"
         return "Save unsaved file as..."
 
+    def p4_checkout(self, context):
+        # https://www.perforce.com/manuals/p4python/Content/P4Python/python.programming.html#Programming_with_P4Python
+
+        from P4 import P4, P4Exception              # Import the module
+        p4 = P4()                                   # Create the P4 instance
+        try:                                        # Catch exceptions with try/except
+            p4.connect()                            # Connect to the Perforce server
+            p4.run("edit", bpy.data.filepath)       # Checkout current file
+            p4.disconnect()                         # Disconnect from the server
+        except P4Exception:
+            for e in p4.errors:                     # Display errors
+                print(e)
+
+    def machin3_save_file (self, context, file):
+        bpy.ops.wm.save_mainfile()
+        t = time.time()
+        localt = time.strftime('%H:%M:%S', time.localtime(t))
+        print("%s | Saved blend: %s" % (localt, file))
+        
+
     def execute(self, context):
         currentblend = bpy.data.filepath
 
         if currentblend:
-            bpy.ops.wm.save_mainfile()
-
-            t = time.time()
-            localt = time.strftime('%H:%M:%S', time.localtime(t))
-            print("%s | Saved blend: %s" % (localt, currentblend))
-            self.report({'INFO'}, 'Saved "%s"' % (os.path.basename(currentblend)))
+            try:
+                self.machin3_save_file(context, currentblend)
+                self.report({'INFO'}, 'Saved "%s"' % (os.path.basename(currentblend)))
+            except RuntimeError:
+                file_mode = os.stat(currentblend).st_mode
+                if bpy.context.preferences.addons['MACHIN3tools'].preferences.use_p4_checkout and file_mode == 33060: # If P4 Python checkout is activated
+                    self.p4_checkout(context)
+                    # Attempt re-save
+                    self.machin3_save_file(context, currentblend)
+                    self.report({'INFO'}, 'Saved "%s"' % (os.path.basename(currentblend)))
+                    self.report({'INFO'}, '%s Was read-only. Checked out in P4...' % currentblend)
+                    
+                else:
+                    self.report({'ERROR'}, '%s is read-only, could not be saved!' % currentblend)
 
         else:
             bpy.ops.wm.save_mainfile('INVOKE_DEFAULT')

--- a/utils/pip.py
+++ b/utils/pip.py
@@ -1,0 +1,141 @@
+# -*- coding:utf-8 -*-
+
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+# <pep8 compliant>
+
+# ----------------------------------------------------------
+# Author: Stephen Leger (s-leger)
+#
+# ----------------------------------------------------------
+import bpy
+import subprocess
+import sys
+
+
+PYPATH = sys.executable #bpy.app.binary_path_python
+
+
+class Pip:
+
+    def __init__(self):
+        self._ensurepip()
+
+    @staticmethod
+    def _ensure_user_site_package():
+        import os
+        import site
+        import sys
+        site_package = site.getusersitepackages()
+        if not os.path.exists(site_package):
+            site_package = bpy.utils.user_resource('SCRIPTS', "site_package", create=True)
+            site.addsitedir(site_package)
+        if site_package not in sys.path:
+            sys.path.append(site_package)
+
+    def _cmd(self, action, options, module):
+        if options is not None and "--user" in options:
+            self._ensure_user_site_package()
+
+        cmd = [PYPATH, "-m", "pip", action]
+
+        if options is not None:
+            cmd.extend(options.split(" "))
+
+        cmd.append(module)
+        return self._run(cmd)
+
+    def _popen(self, cmd):
+        popen = subprocess.Popen(cmd, stdout=subprocess.PIPE, universal_newlines=True)
+        for stdout_line in iter(popen.stdout.readline, ""):
+            yield stdout_line
+        popen.stdout.close()
+        popen.wait()
+
+    def _run(self, cmd):
+        res = False
+        status = ""
+        for line in self._popen(cmd):
+            if "ERROR:" in line:
+                status = line.strip()
+            if "Error:" in line:
+                status = line.strip()
+            print(line)
+            if "Successfully" in line:
+                status = line.strip()
+                res = True
+        return res, status
+
+    def _ensurepip(self):
+        pip_not_found = False
+        try:
+            import pip
+        except ImportError:
+            pip_not_found = True
+            pass
+        if pip_not_found:
+            self._run([PYPATH, "-m", "ensurepip", "--default-pip"])
+
+    @staticmethod
+    def upgrade_pip():
+        return Pip()._cmd("install", "--upgrade", "pip")
+
+    @staticmethod
+    def uninstall(module, options=None):
+        """
+        :param module: string module name with requirements see:[1]
+        :param options: string command line options  see:[2]
+        :return: True on uninstall, False if already removed, raise on Error
+        [1] https://pip.pypa.io/en/stable/reference/pip_install/#id29
+        [2] https://pip.pypa.io/en/stable/reference/pip_install/#id47
+        """
+        if options is None or options.strip() == "":
+            # force confirm
+            options = "-y"
+        return Pip()._cmd("uninstall", options, module)
+
+    @staticmethod
+    def install(module, options=None):
+        """
+        :param module: string module name with requirements see:[1]
+        :param options: string command line options  see:[2]
+        :return: True on install, False if already there, raise on Error
+        [1] https://pip.pypa.io/en/stable/reference/pip_install/#id29
+        [2] https://pip.pypa.io/en/stable/reference/pip_install/#id47
+        """
+        if options is None or options.strip() == "":
+            # store in user writable directory, use wheel, without deps
+            options = "--user --only-binary all --no-deps"
+        return Pip()._cmd("install", options, module)
+
+    @staticmethod
+    def blender_version():
+        """
+        :return: blender version tuple
+        """
+        return bpy.app.version
+
+    @staticmethod
+    def python_version():
+        """
+        :return: python version object
+        """
+        import sys
+        # version.major, version.minor, version.micro
+        return sys.version_info

--- a/utils/registration.py
+++ b/utils/registration.py
@@ -422,6 +422,10 @@ def get_tools():
     # CUSTOMIZE
     classlists, keylists, count = get_customize(classlists, keylists, count)
 
+    # P4 Python
+    classlists, keylists, count = get_p4python(classlists, keylists, count)
+
+
     return classlists, keylists, count
 
 
@@ -780,3 +784,10 @@ def get_tools_pie(classlists=[], keylists=[], count=0):
         count += 1
 
     return classlists, keylists, count
+
+def get_p4python(classlists=[], keylists=[], count=0):
+    classlists.append(classesdict["P4PYTHON"])
+    count += 1
+
+    return classlists, keylists, count
+


### PR DESCRIPTION
When using Perforce (P4) at work it is very likely to submit files and not be able to save them after due to read-only lock.
MACHIN3 tools Save Pie take over the ctrl+S hotkey, so I've added a little bit of logic to check out the file and put it to Default Changelist in P4.

![image](https://user-images.githubusercontent.com/4040177/144406112-a169ce06-5747-421a-8ff2-971265662d44.png)
